### PR TITLE
Fix python ValueError

### DIFF
--- a/nxapi/nxtool.py
+++ b/nxapi/nxtool.py
@@ -169,7 +169,7 @@ if options.full_auto is True:
     results = translate.full_auto()
     if results:
         for result in results:
-            print "{}".format(result)
+            print "{0}".format(result)
     else:
         print "No hits for this filter."
         sys.exit(1)


### PR DESCRIPTION
Fix python 2.6 ValueError
```
Traceback (most recent call last):
  File "./nxtool.py", line 173, in <module>
    print "{}".format(result)
ValueError: zero length field name in format
```